### PR TITLE
Add Linux support

### DIFF
--- a/driver/include/ps4eye.h
+++ b/driver/include/ps4eye.h
@@ -66,7 +66,7 @@ namespace std {
 #if defined(DEBUG)
 #define debug(x...) fprintf(stdout,x)
 #else
-#define debug(x...)
+#define debug(x...) while (false)
 #endif
 
 typedef struct eyeframe

--- a/driver/include/ps4eye.h
+++ b/driver/include/ps4eye.h
@@ -37,7 +37,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <vector>
-#include "CinderOpenCV.h"
+#include <string>
 
 // define shared_ptr in std
 


### PR DESCRIPTION
This does a few things:

1. Remove `CinderOpenCV.h` from `driver/include/ps4eye.h` (so it can be built without Cinder)
2. Fix missing includes
3. Implement performance counters / performance frequency for Linux using `CLOCK_MONOTONIC_RAW`
4. Fix a deprecated libusb call (debug logging)
5. Mention the firmware filename when it's missing or cannot be loaded

Tested only uploading of firmware for PS4 Camera (CUH-ZEY2, using firmware with SHA-1 of fe86162309518a0ffe267075a2fcf728c5856b3e from this repo) and PS5 Camera (CFI-ZEY1, using firmware with SHA-1 of 0fa4da31a12b662a9a80abc8b84932770df8f7e1 [from here](https://github.com/Hackinside/PS5_camera_files)). On Linux, after uploading of firmware is complete, the normal "uvcvideo" kernel module and V4L2 can be used to access the cameras.